### PR TITLE
Re-enable war of the relic (#53)

### DIFF
--- a/production_config/triplea_maps.yaml
+++ b/production_config/triplea_maps.yaml
@@ -1497,22 +1497,21 @@
         <li><b>and some more...</b></li>
         </UL><br/>
   version: 1.5
-# Disable war of the relics until the map parsing performance problems can be resolved: https://github.com/triplea-game/triplea/issues/1128
-# - mapName: war_of_the_relics
-#  url: https://github.com/triplea-maps/war_of_the_relics/releases/download/0.11/war_of_the_relics.zip
-#  description: |
-#    <img src="http://tripleamaps.sourceforge.net/images/TripleA_war_of_the_relics_mini.png" />
-#    <br>
-#    <br>War of the Relics
-#    <br>
-#    <br>The War of the Relics is complex medieval-themed strategy game in which two players build factions of noble lords who use powerful titles and offices to gain strength and crush the opposition. 
-#    <br>Each lord can recruit sworn troops, mercenaries, druids, and ships to his cause, taking over castles and towns via title or conquest.
-#    <br>Three sacred relics must be gathered to a player's faction to anoint one of its nobles as the new king.
-#    <br>A system of random events can thwart the best-laid plans at the most inconvenient times.
-#    <br>
-#    <br>by humbabba
-#    <br>
-#  version: 2.0.3
+ - mapName: war_of_the_relics
+  url: https://github.com/triplea-maps/war_of_the_relics/releases/download/0.11/war_of_the_relics.zip
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_war_of_the_relics_mini.png" />
+    <br>
+    <br>War of the Relics
+    <br>
+    <br>The War of the Relics is complex medieval-themed strategy game in which two players build factions of noble lords who use powerful titles and offices to gain strength and crush the opposition. 
+    <br>Each lord can recruit sworn troops, mercenaries, druids, and ships to his cause, taking over castles and towns via title or conquest.
+    <br>Three sacred relics must be gathered to a player's faction to anoint one of its nobles as the new king.
+    <br>A system of random events can thwart the best-laid plans at the most inconvenient times.
+    <br>
+    <br>by humbabba
+    <br>
+  version: 2.0.3
 - mapName: Empire
   url: https://github.com/triplea-maps/empire/releases/download/0.5/empire.zip
   description: |


### PR DESCRIPTION
Only kills select game load time if 'parse all' is selected, which is a non-default option.
See : https://github.com/triplea-game/triplea/issues/979